### PR TITLE
Change from using Queue to Array

### DIFF
--- a/rucppy.rb
+++ b/rucppy.rb
@@ -36,22 +36,14 @@ end
 
 MAIN_FILE = File.realpath(ARGV[0])
 
-queue = Queue.new
-queue.push MAIN_FILE
+queue = [MAIN_FILE]
 lookup = Set[]
 
-loop do
-  begin
-    source = queue.pop(true)
+while (filepath = queue.pop) && !filepath.nil?
+  next if lookup.include? filepath
 
-    next if lookup.include? source
-
-    lookup.add source
-    new_sources = get_sources(source)
-    new_sources.each { |filename| queue << filename }
-  rescue ThreadError
-    break
-  end
+  lookup.add filepath
+  get_sources(filepath).each { |filename| queue << filename }
 end
 
 files = ''


### PR DESCRIPTION
This PR fixes #1 . It changes from using ruby's builtin Queue class to using Arrays. Queues are mainly used for multi-threaded programming, and in this case, it appears to be an overkill. Normal Arrays can be used and can cut down on complex code. 